### PR TITLE
Removed push plugin due to android setup issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "es6-promise": "4.1.0",
     "events": "1.1.1",
     "kinvey-js-sdk": "3.6.0-ns.3",
-    "nativescript-push-notifications": "0.1.3",
     "nativescript-sqlite": "1.1.7"
   },
   "devDependencies": {


### PR DESCRIPTION
#### Description
The push plugin requires additional setup on Android before the app can be built. This change makes the setup optional.

#### Changes
Remove the push plugin from `package.json`. We will add docs to instruct developers on setting it up manually.

#### Tests
N/A