### PR TITLE
Remove definitions from .gitignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -17,6 +17,7 @@ npm-debug.log
 .travis.yml
 .github
 *.ts
+!*.d.ts
 *.js.map
 hooks/
 scripts/


### PR DESCRIPTION
FIX: The `kinvey.d.ts` is getting npm-ignored when publishing.