### PR TITLE
Sdk on windows and a fix for a fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "url": "git@github.com:Kinvey/nativescript-sdk"
   },
   "scripts": {
-    "build": "del 'src/**/*.js' && del 'push/**/*.js' && tsc",
+    "build": "rm -rf 'src/**/*.js' && rm -rf 'push/**/*.js' && tsc",
     "preversion": "rm -rf node_modules && npm install && npm run build",
     "postversion": "git push && git push --tags"
   },
@@ -29,7 +29,6 @@
     "nativescript-sqlite": "1.1.7"
   },
   "devDependencies": {
-    "del-cli": "1.1.0",
     "nativescript-dev-typescript": "0.4.5",
     "tns-core-modules": "3.0.1",
     "tns-platform-declarations": "3.0.1",

--- a/src/cache/sqlite.ts
+++ b/src/cache/sqlite.ts
@@ -142,7 +142,7 @@ class SQLiteAdapter {
 
   removeById(collection, id) {
     const query = 'DELETE FROM #{collection} WHERE key = ?';
-    return this.openTransaction(collection, query, id, true)
+    return this.openTransaction(collection, query, [id], true)
       .then((response) => {
         const count = response[0];
 

--- a/src/cache/sqlite.ts
+++ b/src/cache/sqlite.ts
@@ -141,8 +141,8 @@ class SQLiteAdapter {
   }
 
   removeById(collection, id) {
-    const query = ['DELETE FROM #{collection} WHERE key = ?', [id]];
-    return this.openTransaction(collection, query, null, true)
+    const query = 'DELETE FROM #{collection} WHERE key = ?';
+    return this.openTransaction(collection, query, id, true)
       .then((response) => {
         const count = response[0];
 


### PR DESCRIPTION
#### Description
This PR facilitates building the SDK on Windows by removing a library which overlaps with Windows syntax for deletion (as per MLIBZ-1958) and hopefully really fixes MLIBZ-1953 since I had misused the api of the SQLiteAdapter openTransaction() method, which lead to erros when using DataStoreType.Cache (other types worked).

#### Changes
Slightly changed build command and fixed parameters for openTransaction() of SQLiteAdapter.
