### PR TITLE
Active User Storage

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -14,7 +14,8 @@ npm-debug.log
 .travis.yml
 .github
 *.ts
-!*.d.ts
+*.d.ts
+!kinvey.d.ts
 *.js.map
 hooks/
 scripts/

--- a/src/cache/index.ts
+++ b/src/cache/index.ts
@@ -1,9 +1,9 @@
 import { isDefined } from 'kinvey-js-sdk/dist/export';
 import { CacheMiddleware as CoreCacheMiddleware } from 'kinvey-js-sdk/dist/request';
-import KinveyStorage from 'kinvey-js-sdk/dist/request/src/middleware/src/storage';
+import { Storage as CoreStorage } from 'kinvey-js-sdk/dist/request/src/middleware/src/storage';
 import { SQLite } from './sqlite';
 
-class Storage extends KinveyStorage {
+class Storage extends CoreStorage {
   name: string;
 
   constructor(name: string) {
@@ -23,7 +23,7 @@ class Storage extends KinveyStorage {
 }
 
 export class CacheMiddleware extends CoreCacheMiddleware {
-  loadStorage(name): KinveyStorage {
+  loadStorage(name): Storage {
     return new Storage(name);
   }
 }

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,13 +1,11 @@
-import isString from 'lodash/isString';
-import { Client as CoreClient, KinveyError, isDefined } from 'kinvey-js-sdk/dist/export';
-import Log from 'kinvey-js-sdk/dist/utils';
+import { Client as CoreClient, KinveyError, isDefined, Log } from 'kinvey-js-sdk/dist/export';
 import { SecureStorage } from './secure';
 const storage = new SecureStorage();
 
 class ActiveUserStorage {
-  get(key) {
-    if (!isString(key)) {
-      throw new KinveyError('ActiveUserStorage key must be a string.');
+  get(key: string) {
+    if (typeof key !== 'string') {
+      throw new KinveyError('The key argument must be a string.');
     }
 
     try {
@@ -18,18 +16,35 @@ class ActiveUserStorage {
     }
   }
 
-  set(key, value) {
-    if (!isString(key)) {
-      throw new KinveyError('ActiveUserStorage key must be a string.');
+  set(key: string, value: string|Object) {
+    if (typeof key !== 'string') {
+      throw new KinveyError('The key argument must be a string.');
+    }
+
+    if (value !== null && value !== undefined && typeof value === 'object') {
+      value = JSON.stringify(value);
+    }
+
+    if (value !== null && value !== undefined && typeof value !== 'string') {
+      value = String(value);
     }
 
     if (isDefined(value)) {
-      storage.set(key, JSON.stringify(value));
+      storage.set(key, value);
     } else {
-      storage.remove(key);
+      this.remove(key);
     }
 
     return value;
+  }
+
+  remove(key: string) {
+    if (typeof key !== 'string') {
+      throw new KinveyError('The key argument must be a string.');
+    }
+
+    storage.remove(key);
+    return null;
   }
 }
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,0 +1,42 @@
+import isString from 'lodash/isString';
+import { Client as CoreClient, KinveyError, isDefined } from 'kinvey-js-sdk/dist/export';
+import Log from 'kinvey-js-sdk/dist/utils';
+import { SecureStorage } from './secure';
+const storage = new SecureStorage();
+
+class ActiveUserStorage {
+  get(key) {
+    if (!isString(key)) {
+      throw new KinveyError('ActiveUserStorage key must be a string.');
+    }
+
+    try {
+      return JSON.parse(storage.get(key));
+    } catch (e) {
+      Log.debug('Unable to parse stored active user.', e);
+      return null;
+    }
+  }
+
+  set(key, value) {
+    if (!isString(key)) {
+      throw new KinveyError('ActiveUserStorage key must be a string.');
+    }
+
+    if (isDefined(value)) {
+      storage.set(key, JSON.stringify(value));
+    } else {
+      storage.remove(key);
+    }
+
+    return value;
+  }
+}
+
+export class Client extends CoreClient {
+  static init(config) {
+    const client = CoreClient.init(config);
+    client.activeUserStorage = new ActiveUserStorage();
+    return client;
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,11 +1,9 @@
-import { Kinvey } from 'kinvey-js-sdk/dist/kinvey';
 import { CacheRack, NetworkRack } from 'kinvey-js-sdk/dist/request'
 import { MobileIdentityConnect } from 'kinvey-js-sdk/dist/identity';
-import { ActiveUserHelper } from 'kinvey-js-sdk/dist/entity/src/activeUserHelper';
+import { Kinvey } from './kinvey';
 import { CacheMiddleware } from './cache';
 import { HttpMiddleware } from './http';
 import { Popup } from './popup';
-import { SecureStorage } from './secure';
 import { FileStore } from './filestore';
 
 // Setup racks
@@ -15,11 +13,8 @@ NetworkRack.useHttpMiddleware(new HttpMiddleware());
 // Setup Popup class
 MobileIdentityConnect.usePopupClass(Popup);
 
-// Setup Active User Storage class
-ActiveUserHelper.useStorage(SecureStorage);
-
 // Replace Files implementation
-Kinvey.Files = new FileStore();
+(Kinvey as any).Files = new FileStore();
 
 // Export
 export { Kinvey };

--- a/src/kinvey.d.ts
+++ b/src/kinvey.d.ts
@@ -7,8 +7,8 @@ import { Observable } from 'rxjs/Observable';
 export namespace Kinvey {
   var appVersion: string;
   function initialize(config: ClientConfig): Promise<User>;
-  function init(config: ClientConfig): void;
-  
+  function init(config: ClientConfig): Client;
+
   interface PingResponse {
     version: string,
     kinvey: string,

--- a/src/kinvey.ts
+++ b/src/kinvey.ts
@@ -1,0 +1,45 @@
+import { Promise } from 'es6-promise';
+import url from 'url';
+import {
+  Kinvey as CoreKinvey,
+  isDefined,
+  KinveyError,
+  CacheRequest,
+  RequestMethod
+} from 'kinvey-js-sdk/dist/export';
+import { Client } from './client';
+
+const USERS_NAMESPACE = 'user';
+const ACTIVE_USER_COLLECTION_NAME = 'kinvey_active_user';
+
+interface ClientConfig {
+  apiHostname?: string,
+  micHostname?: string,
+  liveServiceHostname?: string,
+  appKey: string,
+  appSecret?: string,
+  masterSecret?: string,
+  encryptionKey?: string,
+  defaultTimeout?: number
+}
+
+export class Kinvey extends CoreKinvey {
+  static initialize(config) {
+    const client = Kinvey.init(config);
+    return Promise.resolve(client.getActiveUser());
+  }
+
+  static init(config = <ClientConfig>{}) {
+    if (!isDefined(config.appKey)) {
+      throw new KinveyError('No App Key was provided.'
+        + ' Unable to create a new Client without an App Key.');
+    }
+
+    if (!isDefined(config.appSecret) && !isDefined(config.masterSecret)) {
+      throw new KinveyError('No App Secret or Master Secret was provided.'
+        + ' Unable to create a new Client without an App Secret.');
+    }
+
+    return Client.init(config);
+  }
+}

--- a/src/kinvey.ts
+++ b/src/kinvey.ts
@@ -12,24 +12,13 @@ import { Client } from './client';
 const USERS_NAMESPACE = 'user';
 const ACTIVE_USER_COLLECTION_NAME = 'kinvey_active_user';
 
-interface ClientConfig {
-  apiHostname?: string,
-  micHostname?: string,
-  liveServiceHostname?: string,
-  appKey: string,
-  appSecret?: string,
-  masterSecret?: string,
-  encryptionKey?: string,
-  defaultTimeout?: number
-}
-
 export class Kinvey extends CoreKinvey {
   static initialize(config) {
     const client = Kinvey.init(config);
     return Promise.resolve(client.getActiveUser());
   }
 
-  static init(config = <ClientConfig>{}) {
+  static init(config = <any>{}) {
     if (!isDefined(config.appKey)) {
       throw new KinveyError('No App Key was provided.'
         + ' Unable to create a new Client without an App Key.');

--- a/src/secure/secure.android.ts
+++ b/src/secure/secure.android.ts
@@ -11,23 +11,23 @@ export class SecureStorage {
   }
 
   get(key): any {
-    if (key === null || key === undefined) {
-      throw new Error('A key must be provided.');
+    if (typeof key !== 'string') {
+      throw new Error('The key argument must be a string.');
     }
 
      return Hawk.get(key);
   }
 
   set(key, value): boolean {
-    if (key === null || key === undefined) {
-      throw new Error('A key must be provided.');
+    if (typeof key !== 'string') {
+      throw new Error('The key argument must be a string.');
     }
 
-    if (value !== null && typeof value === 'object') {
+    if (value !== null && value !== undefined && typeof value === 'object') {
       value = JSON.stringify(value);
     }
 
-    if (value !== null && typeof value !== 'string') {
+    if (value !== null && value !== undefined && typeof value !== 'string') {
       value = String(value);
     }
 
@@ -35,8 +35,8 @@ export class SecureStorage {
   }
 
   remove(key): boolean {
-    if (key === null || key === undefined) {
-      throw new Error('A key must be provided.');
+    if (typeof key !== 'string') {
+      throw new Error('The key argument must be a string.');
     }
 
     return Hawk.delete(key);

--- a/src/secure/secure.ios.ts
+++ b/src/secure/secure.ios.ts
@@ -4,8 +4,8 @@ export class SecureStorage {
   private defaultService = 'kinvey_nativescript_sdk';
 
   get(key): any {
-    if (key === null || key === undefined) {
-      throw new Error('A key must be provided.');
+    if (typeof key !== 'string') {
+      throw new Error('The key argument must be a string.');
     }
 
     const query = SAMKeychainQuery.new();
@@ -21,15 +21,15 @@ export class SecureStorage {
   }
 
   set(key, value): boolean {
-    if (key === null || key === undefined) {
-      throw new Error('A key must be provided.');
+    if (typeof key !== 'string') {
+      throw new Error('The key argument must be a string.');
     }
 
-    if (value !== null && typeof value === 'object') {
+    if (value !== null && value !== undefined && typeof value === 'object') {
       value = JSON.stringify(value);
     }
 
-    if (value !== null && typeof value !== 'string') {
+    if (value !== null && value !== undefined && typeof value !== 'string') {
       value = String(value);
     }
 
@@ -44,8 +44,8 @@ export class SecureStorage {
   }
 
   remove(key): boolean {
-    if (key === null || key === undefined) {
-      throw new Error('A key must be provided.');
+    if (typeof key !== 'string') {
+      throw new Error('The key argument must be a string.');
     }
 
     const query = SAMKeychainQuery.new();


### PR DESCRIPTION
#### Description
Refactor to use the new active user storage API.

#### Changes
- Override the `Kinvey` class to use the custom `Client` class that stores the active user using keychain on iOS or Hawk on Android.
- Ignore all `.d.ts` files except `kinvey.d.ts` for npm.