### PR TITLE
MLIBZ-2113: Add hook to use correct PubNub module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,8 +5,8 @@ npm-debug.log
 package-lock.json
 
 # Src files
-*.js
-!hooks/**/*.js
+src/**/*.js
+push/**/*.js
 
 # MacOS Files
 .DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ package-lock.json
 
 # Src files
 *.js
+!hooks/**/*.js
 
 # MacOS Files
 .DS_Store

--- a/.npmignore
+++ b/.npmignore
@@ -17,8 +17,6 @@ npm-debug.log
 *.d.ts
 !kinvey.d.ts
 *.js.map
-hooks/
-scripts/
 README.md
 CONTRIBUTING.md
 CHANGELOG.md

--- a/hooks/before-prepare.js
+++ b/hooks/before-prepare.js
@@ -1,0 +1,15 @@
+var replace = require('replace-in-file');
+
+module.exports = function() {
+  return replace({
+    files: './node_modules/kinvey-js-sdk/dist/live/live-service.js',
+    from: /require\('pubnub'\);/g,
+    to: "require('pubnub/lib/nativescript');"
+  })
+    .then(changes => {
+      console.log('Modified files:', changes.join(', '));
+    })
+    .catch(error => {
+      console.log('Error occurred:', error);
+    });
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kinvey-nativescript-sdk",
-  "version": "3.9.1",
+  "version": "3.9.2-beta.8",
   "description": "Kinvey JavaScript SDK for NativeScript applications.",
   "homepage": "http://www.kinvey.com",
   "bugs": {
@@ -22,13 +22,17 @@
     "ci.tslint": "npm i && npm run lint",
     "lint": "tslint **/*.ts --exclude **/node_modules/**/* --exclude **/*.d.ts",
     "preversion": "rm -rf node_modules && npm install && npm run build",
-    "postversion": "git push && git push --tags"
+    "postversion": "git push && git push --tags",
+    "postinstall": "node postinstall.js",
+    "preuninstall": "node preuninstall.js"
   },
   "dependencies": {
     "es6-promise": "4.1.0",
     "events": "1.1.1",
-    "kinvey-js-sdk": "3.8.1",
-    "nativescript-sqlite": "1.1.7"
+    "kinvey-js-sdk": "3.9.2-beta.3",
+    "nativescript-hook": "0.2.1",
+    "nativescript-sqlite": "1.1.7",
+    "replace-in-file": "3.0.0-beta.2"
   },
   "devDependencies": {
     "rimraf": "2.6.2",
@@ -39,6 +43,13 @@
     "typescript": "2.3.4"
   },
   "nativescript": {
+    "hooks": [
+      {
+        "type": "before-prepare",
+        "script": "hooks/before-prepare.js",
+        "inject": true
+      }
+    ],
     "platforms": {
       "ios": "3.0.0",
       "android": "3.0.0"

--- a/postinstall.js
+++ b/postinstall.js
@@ -1,0 +1,1 @@
+require('nativescript-hook')(__dirname).postinstall();

--- a/preuninstall.js
+++ b/preuninstall.js
@@ -1,0 +1,1 @@
+require('nativescript-hook')(__dirname).preuninstall();


### PR DESCRIPTION
This PR adds a [hook](nativescript-hook) that changes `require('pubnub');` to `require('pubnub/dist/nativescript')`.