### PR TITLE
fixing count

### DIFF
--- a/kinvey.d.ts
+++ b/kinvey.d.ts
@@ -280,9 +280,7 @@ export namespace Kinvey {
     find(query?: Query, options?: RequestOptions): Observable<T[]>;
     findById(id: string, options?: RequestOptions): Observable<T>;
     group(aggregation: Aggregation, options?: RequestOptions): Observable<{}>;
-    count(query?: Query, options?: RequestOptions): Observable<{
-      count: number
-    }>;
+    count(query?: Query, options?: RequestOptions): Observable<number>;
     create(entities: {}, options?: RequestOptions): Promise<T>;
     update(entities: {}, options?: RequestOptions): Promise<T>;
     save(entity: {}, options?: RequestOptions): Promise<T>;


### PR DESCRIPTION
count method should return an Observable<number> and not an Observable<{count:number}>

#### Description
Change made in the typescript definition file.